### PR TITLE
165. Compare Version Numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ continually updating 😃.
 * [67. Add Binary](./src/0067_add_binary/add_binary.go)&nbsp;&nbsp;&nbsp;*`brute force`*
 * [76. Minimum Window Substring](./src/0076_minimum_window_substring/minimum_window_substring.go) &nbsp;&nbsp;&nbsp;*`sliding window`*
 * [125. Valid Palindrome](./src/0125_valid_palindrome/valid_palindrome.go)&nbsp;&nbsp;&nbsp;*`string;`*&nbsp;&nbsp;*`double index`*
+* [165. Compare Version Numbers](src/0165_compare_version_numbers/compare_version_numbers.go)
 * [344. Reverse String](./src/0344_reverse_string/reverse_string.go)&nbsp;&nbsp;&nbsp;*`string;`*&nbsp;&nbsp;*`double index`*
 * [345. Reverse Vowels of a String](./src/0345_reverse_vowels_of_a_string/reverse_vowels.go)&nbsp;&nbsp;&nbsp;*`string;`*&nbsp;&nbsp;*`double index`*
 * [438. Find All Anagrams in a String](./src/0438_all_anagrams_in_a_string/all_anagrams_in_a_string.go)&nbsp;&nbsp;&nbsp;*`sliding window`*

--- a/src/0165_compare_version_numbers/compare_version_numbers.go
+++ b/src/0165_compare_version_numbers/compare_version_numbers.go
@@ -1,0 +1,56 @@
+/*
+165. Compare Version Numbers
+https://leetcode.com/problems/compare-version-numbers/
+
+Compare two version numbers version1 and version2.
+If version1 > version2 return 1; if version1 < version2 return -1;otherwise return 0.
+
+You may assume that the version strings are non-empty and contain only digits and the . character.
+
+The . character does not represent a decimal point and is used to separate number sequences.
+
+For instance, 2.5 is not "two and a half" or "half way to version three",
+it is the fifth second-level revision of the second first-level revision.
+
+You may assume the default revision number for each level of a version number to be 0.
+For example, version number 3.4 has a revision number of 3 and 4 for its first and second level revision number.
+Its third and fourth level revision number are both 0.
+
+Note:
+
+Version strings are composed of numeric strings separated by dots . and this numeric strings may have leading zeroes.
+Version strings do not start or end with dots, and they will not be two consecutive dots.
+*/
+// time: 2019-01-07
+
+package compareversionnumbers
+
+import (
+	"strconv"
+	"strings"
+)
+
+// time complexity: O( max n, m )
+// space complexity: O(n+m)
+func compareVersion(version1 string, version2 string) int {
+	var (
+		v1 = strings.Split(version1, ".")
+		v2 = strings.Split(version2, ".")
+	)
+	for i := 0; i < len(v1) || i < len(v2); i++ {
+		var v1N, v2N int
+		if i < len(v1) {
+			v1N, _ = strconv.Atoi(v1[i])
+		}
+		if i < len(v2) {
+			v2N, _ = strconv.Atoi(v2[i])
+		}
+
+		if v1N > v2N {
+			return 1
+		} else if v1N < v2N {
+			return -1
+		}
+	}
+	return 0
+}

--- a/src/0165_compare_version_numbers/compare_version_numbers_test.go
+++ b/src/0165_compare_version_numbers/compare_version_numbers_test.go
@@ -1,0 +1,23 @@
+package compareversionnumbers
+
+import "testing"
+
+func TestCompareVersion(t *testing.T) {
+	type arg struct {
+		version1 string
+		version2 string
+	}
+
+	testCases := []arg{
+		{version1: "0.1", version2: "1.1"},
+		{version1: "1.0.1", version2: "1"},
+		{version1: "1.01", version2: "1.001"},
+	}
+	expected := []int{-1, 1, 0}
+
+	for index, data := range testCases {
+		if res := compareVersion(data.version1, data.version2); res != expected[index] {
+			t.Errorf("expected %d, got %d", expected[index], res)
+		}
+	}
+}

--- a/src/README.md
+++ b/src/README.md
@@ -60,6 +60,7 @@
 |0144|[144. Binary Tree Preorder Traversal](0144_binary_tree_preorder_traversal/binary_tree_preorder_traversal.go)|Medium|*`binary tree`*|
 |0150|[150. Evaluate Reverse Polish Notation](0150_evaluate_reverse_polish_notation/evaluate_reverse_polish_notation.go)|Medium|*`stack`*|
 |0153|[153. Find Minimum in Rotated Sorted Array](0153_find_minimum_in_rotated_sorted_array/fmirsa.go)|Medium|*`binary search`*|
+|0165|[165. Compare Version Numbers](0165_compare_version_numbers/compare_version_numbers.go)|Medium|*`string`*|
 |0167|[Two Sum II - Input array is sorted](./0167_two_sum2/two_sum2.go)|Easy|*`对撞指针(双索引)`*|
 |0198|[House Robber](./0198_house_robber/house_robber.go)|Easy|*`memory search;`* *`dynamic programming`*|
 |0209|[Minimum Size Subarray Sum](./0209_minimum_size_subarray_sum/minimum_size_subarray_sum.go)|Medium|*`sliding window`*|


### PR DESCRIPTION

https://leetcode.com/problems/compare-version-numbers/

Compare two version numbers version1 and version2.
If version1 > version2 return 1; if version1 < version2 return -1;otherwise return 0.

You may assume that the version strings are non-empty and contain only digits and the . character.

The . character does not represent a decimal point and is used to separate number sequences.

For instance, 2.5 is not "two and a half" or "half way to version three",
it is the fifth second-level revision of the second first-level revision.

You may assume the default revision number for each level of a version number to be 0.
For example, version number 3.4 has a revision number of 3 and 4 for its first and second level revision number.
Its third and fourth level revision number are both 0.

Note:

Version strings are composed of numeric strings separated by dots . and this numeric strings may have leading zeroes.
Version strings do not start or end with dots, and they will not be two consecutive dots.