### PR TITLE
235. Lowest Common Ancestor of a Binary Search Tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ continually updating 😃.
 * [112. Path Sum](./src/0112_path_sum/path_sum.go)&nbsp;&nbsp;&nbsp;*`binary tree;`*&nbsp;&nbsp;&nbsp;*`dfs`*
 * [144. Binary Tree Preorder Traversal](src/0144_binary_tree_preorder_traversal/binary_tree_preorder_traversal.go)&nbsp;&nbsp;&nbsp;*`binary tree;`*&nbsp;&nbsp;&nbsp;*`pre-order traversal`*
 * [226. Invert Binary Tree](./src/0226_invert_binary_tree/invert_binary_tree.go)&nbsp;&nbsp;&nbsp;*`binary tree;`*
+* [235. Lowest Common Ancestor of a Binary Search Tree](src/0235_lowest_common_ancestor_of_a_binary_search_tree/lcaoabst.go)&nbsp;&nbsp;&nbsp;*`binary tree;`*
 
 ### Binary Search
 * [33. Search in Rotated Sorted Array](./src/0033_search_in_rotated_sorted_array/search_in_rotated_sorted_array.go)&nbsp;&nbsp;&nbsp;*`array;`*&nbsp;&nbsp;*`binary search`*

--- a/src/0235_lowest_common_ancestor_of_a_binary_search_tree/lcaoabst.go
+++ b/src/0235_lowest_common_ancestor_of_a_binary_search_tree/lcaoabst.go
@@ -1,0 +1,42 @@
+/*
+235. Lowest Common Ancestor of a Binary Search Tree
+https://leetcode.com/problems/lowest-common-ancestor-of-a-binary-search-tree/
+
+Given a binary search tree (BST), find the lowest common ancestor (LCA) of two given nodes in the BST.
+
+According to the definition of LCA on Wikipedia:
+“The lowest common ancestor is defined between two nodes p and q as the lowest node in T that has
+both p and q as descendants (where we allow a node to be a descendant of itself).”
+
+Note:
+All of the nodes' values will be unique.
+p and q are different and both values will exist in the BST.
+*/
+// time: 2019-01-07
+
+package lcaoabst
+
+// TreeNode Definition for TreeNode.
+type TreeNode struct {
+	Val   int
+	Left  *TreeNode
+	Right *TreeNode
+}
+
+// recursive
+// time complexity: O(log n), where n is the nodes number of the tree.
+// space complexity: O(h), where h is the height of the tree.
+func lowestCommonAncestor(root, p, q *TreeNode) *TreeNode {
+	if root == nil {
+		return root
+	}
+
+	if root.Val > p.Val && root.Val > q.Val {
+		return lowestCommonAncestor(root.Left, p, q)
+	}
+
+	if root.Val < p.Val && root.Val < q.Val {
+		return lowestCommonAncestor(root.Right, p, q)
+	}
+	return root
+}

--- a/src/0235_lowest_common_ancestor_of_a_binary_search_tree/lcaoabst_test.go
+++ b/src/0235_lowest_common_ancestor_of_a_binary_search_tree/lcaoabst_test.go
@@ -10,10 +10,10 @@ func TestLowestCommonAncestor(t *testing.T) {
 	}
 
 	testCases := []arg{
-		{root: createBinaryTree([]int{6, 2, 8, 0, 4, 7, 9}), p: &TreeNode{Val: 2}, q: &TreeNode{Val: 8}},
+		{root: createBinaryTree([]int{6, 2, 8, 0, 4, 7, 9, -1, 1, 3, 5}), p: &TreeNode{Val: 3}, q: &TreeNode{Val: 5}},
 		{p: &TreeNode{Val: 2}, q: &TreeNode{Val: 8}},
 	}
-	expected := []*TreeNode{{Val: 6}, nil}
+	expected := []*TreeNode{{Val: 4}, nil}
 
 	for index, data := range testCases {
 		if res := lowestCommonAncestor(data.root, data.p, data.q); res != nil && res.Val != expected[index].Val {

--- a/src/0235_lowest_common_ancestor_of_a_binary_search_tree/lcaoabst_test.go
+++ b/src/0235_lowest_common_ancestor_of_a_binary_search_tree/lcaoabst_test.go
@@ -1,0 +1,39 @@
+package lcaoabst
+
+import (
+	"testing"
+)
+
+func TestLowestCommonAncestor(t *testing.T) {
+	type arg struct {
+		root, p, q *TreeNode
+	}
+
+	testCases := []arg{
+		{root: createBinaryTree([]int{6, 2, 8, 0, 4, 7, 9}), p: &TreeNode{Val: 2}, q: &TreeNode{Val: 8}},
+		{p: &TreeNode{Val: 2}, q: &TreeNode{Val: 8}},
+	}
+	expected := []*TreeNode{{Val: 6}, nil}
+
+	for index, data := range testCases {
+		if res := lowestCommonAncestor(data.root, data.p, data.q); res != nil && res.Val != expected[index].Val {
+			t.Errorf("expected %v, got %v", expected[index], res)
+		} else if res == nil && res != expected[index] {
+			t.Errorf("expected %v, got %v", expected[index], res)
+		}
+	}
+}
+
+func createBinaryTree(nums []int) *TreeNode {
+	return performCreate(nums, 0)
+}
+
+func performCreate(nums []int, index int) *TreeNode {
+	if index >= len(nums) {
+		return nil
+	}
+	root := &TreeNode{Val: nums[index]}
+	root.Left = performCreate(nums, 2*index+1)
+	root.Right = performCreate(nums, 2*index+2)
+	return root
+}

--- a/src/README.md
+++ b/src/README.md
@@ -71,6 +71,7 @@
 |0217|[217. Contains Duplicate](0217_contains_duplicate/contains_duplicate.go)|Easy|*`map`*|
 |0219|[219. Contains Duplicate II](0219_contains_duplicate_2/contains_duplicate_2.go)|Easy|*`map`*|
 |0226|[Invert Binary Tree](./0226_invert_binary_tree/invert_binary_tree.go)|Easy|*`recursion; `* *`binary tree`*|
+|0235|[235. Lowest Common Ancestor of a Binary Search Tree](0235_lowest_common_ancestor_of_a_binary_search_tree/lcaoabst.go)|Easy|*`recursion; `* *`binary tree`*|
 |0283|[Move Zeroes(solution1)](./0283_move_zeroes/move_zeroes.go) <br/>  [Move Zeroes(solution2)](./0283_move_zeroes/move_zeroes2.go)|Easy|*`array`*|
 |0300|[Longest Increasing Subsequence](./0300_longest_increasing_subsequence/lis.go)|Medium|*`dp`*|
 |0303|[303. Range Sum Query - Immutable](0303_range_sum_query/rsqim.go)|Easy||


### PR DESCRIPTION

https://leetcode.com/problems/lowest-common-ancestor-of-a-binary-search-tree/

Given a binary search tree (BST), find the lowest common ancestor (LCA) of two given nodes in the BST.

According to the definition of LCA on Wikipedia:
“The lowest common ancestor is defined between two nodes p and q as the lowest node in T that has
both p and q as descendants (where we allow a node to be a descendant of itself).”

Note:
All of the nodes' values will be unique.
p and q are different and both values will exist in the BST.